### PR TITLE
Feature 6 drive argument

### DIFF
--- a/autotest.cfg
+++ b/autotest.cfg
@@ -11,6 +11,7 @@ moongen_dir=/home/networkadmin/MoonGen
 fqdn=guest.gierens.de
 vcpus=4
 memory=4096
+root_disk_file=/dev/ssd/vm_guest
 test_iface=ens4
 test_iface_addr=0000:00:04.0
 test_iface_driv=virtio-pci

--- a/autotest.py
+++ b/autotest.py
@@ -182,6 +182,12 @@ def setup_parser() -> ArgumentParser:
                                   default='pc',
                                   help='Machine type of the guest',
                                   )
+    run_guest_parser.add_argument('-D',
+                                  '--disk',
+                                  type=FileType('rw'),
+                                  help='Disk image path for the guest\'s ' +
+                                       'root partition.',
+                                  )
     run_guest_parser.add_argument('-d',
                                   '--debug',
                                   action='store_true',

--- a/autotest.py
+++ b/autotest.py
@@ -663,7 +663,10 @@ def run_guest(args: Namespace, conf: ConfigParser) -> None:
             host.setup_test_br_tap()
         else:
             host.setup_test_macvtap()
-        host.run_guest(args.interface, args.machine, args.debug,
+
+        disk = args.disk if args.disk else conf['guest']['root_disk_file']
+
+        host.run_guest(args.interface, args.machine, disk, args.debug,
                        args.ioregionfd)
     except Exception:
         host.kill_guest()
@@ -1049,7 +1052,9 @@ def test_load_latency(
         dut: Server
         mac: str
         if interface in ['brtap', 'macvtap']:
-            host.run_guest(net_type=interface, machine_type='pc')
+            disk = args.disk if args.disk else conf['guest']['root_disk_file']
+            host.run_guest(net_type=interface, machine_type='pc',
+                           root_disk=disk)
             dut = guest
             mac = '52:54:00:fa:00:60'
         else:

--- a/autotest.py
+++ b/autotest.py
@@ -1052,7 +1052,7 @@ def test_load_latency(
         dut: Server
         mac: str
         if interface in ['brtap', 'macvtap']:
-            disk = args.disk if args.disk else conf['guest']['root_disk_file']
+            disk = conf['guest']['root_disk_file']
             host.run_guest(net_type=interface, machine_type='pc',
                            root_disk=disk)
             dut = guest

--- a/server.py
+++ b/server.py
@@ -700,6 +700,7 @@ class Host(Server):
     def run_guest(self: 'Host',
                   net_type: str,
                   machine_type: str,
+                  root_disk: str,
                   debug_qemu: bool = False,
                   use_ioregionfd: bool = False
                   ) -> None:
@@ -713,6 +714,8 @@ class Host(Server):
             Test interface network type
         machine_type : str
             Guest machine type
+        root_disk : str
+            Path to the disk file for guest's root partition
         debug_qemu : bool
             True if you want to attach GDB to Qemu. The GDB server will
             be bound to port 1234.
@@ -752,7 +755,7 @@ class Host(Server):
             ' -enable-kvm' +
             # TODO the disk needs to be dynamically set by the config
             # we might also wanna include commands ot make the image
-            ' -drive id=root,format=raw,file=/dev/ssd/vm_guest,if=none,' +
+            f' -drive id=root,format=raw,file={root_disk},if=none,' +
             'cache=none' +
             f' -device virtio-blk-{dev_type},id=rootdisk,drive=root' +
             ' -cdrom /home/networkadmin/images/guest_init.iso' +


### PR DESCRIPTION
Add `root_disk` argument to `Host.run_guest`. Added the variable `root_disk_file` to the `guest` section in the `autotest.cfg` config file. The `test_load_latency` function uses this one. The `run-guest` command alternatively has a `-D/--disk` argument now.

Resolves #6