### PR TITLE
Add Shell Server Exclusion

### DIFF
--- a/autotest.py
+++ b/autotest.py
@@ -1388,10 +1388,17 @@ def shell(args: Namespace, conf: ConfigParser) -> None:
     __do_nothing(readline)
 
     # create servers
-    host: Host
-    guest: Guest
-    loadgen: LoadGen
-    host, guest, loadgen = create_servers(conf).values()
+    host: Host = None
+    guest: Guest = None
+    loadgen: LoadGen = None
+    servers = create_servers(conf, host=args.host, guest=args.guest,
+                             loadgen=args.loadgen)
+    if 'host' in servers:
+        host = servers['host']
+    if 'guest' in servers:
+        guest = servers['guest']
+    if 'loadgen' in servers:
+        loadgen = servers['loadgen']
 
     # start interactive shell with globals and locals
     variables = globals().copy()

--- a/autotest.py
+++ b/autotest.py
@@ -392,11 +392,31 @@ def setup_parser() -> ArgumentParser:
         help='''Enter a Python3 shell with access to the Server objects.
         This is useful for development and debugging.'''
     )
+    shell_parser.add_argument('-H',
+                              '--exclude-host',
+                              action='store_false',
+                              default=True,
+                              dest='host',
+                              help='''Do not create the Host object.''',
+                              )
+    shell_parser.add_argument('-G',
+                              '--exclude-guest',
+                              action='store_false',
+                              default=True,
+                              dest='guest',
+                              help='''Do not create the Guest object.''',
+                              )
+    shell_parser.add_argument('-L',
+                              '--exclude-loadgen',
+                              action='store_false',
+                              default=True,
+                              dest='loadgen',
+                              help='''Do not create the LoadGen object.''',
+                              )
 
     __do_nothing(ping_parser)
     __do_nothing(kill_guest_parser)
     __do_nothing(teardown_network_parser)
-    __do_nothing(shell_parser)
 
     # return the parser
     return parser


### PR DESCRIPTION
Add `-H/--exclude-host`, `-G/--exclude-guest` and `-L/--exclude-loadgen` arguments to the `shell` parser, and altered `shell` command to take them into account when creating the servers.

Resolves #38 