### PR TITLE
Renew Device Bind and Unbind

### DIFF
--- a/server.py
+++ b/server.py
@@ -608,7 +608,12 @@ class Server(ABC):
         Returns
         -------
         """
-        _ = self.exec(f'sudo dpdk-devbind.py -u {dev_addr}')
+        cmd = f'sudo dpdk-devbind.py -u {dev_addr}'
+
+        if self.nixos:
+            _ = self.exec(f'nix-shell -p dpdk --run "{cmd}"')
+        else:
+            _ = self.exec(cmd)
 
     def bind_nics_to_dpdk(self: 'Server') -> None:
         """

--- a/server.py
+++ b/server.py
@@ -625,7 +625,12 @@ class Server(ABC):
         Returns
         -------
         """
-        _ = self.exec(f'cd {self.moongen_dir}; sudo ./bind-interfaces.sh')
+        cmd = f'cd {self.moongen_dir}; sudo ./bind-interfaces.sh'
+
+        if self.nixos:
+            _ = self.exec(f'nix-shell -p dpdk --run "{cmd}"')
+        else:
+            _ = self.exec(cmd)
 
     def bind_test_iface(self: 'Server') -> None:
         """

--- a/server.py
+++ b/server.py
@@ -677,7 +677,13 @@ class Server(ABC):
         Returns
         -------
         """
-        output = self.exec("dpdk-devbind.py -s | grep 'drv=igb_uio'")
+        cmd = "dpdk-devbind.py -s | grep 'drv=igb_uio'"
+        output: str
+        if self.nixos:
+            output = self.exec(f'nix-shell -p dpdk --run "{cmd}"')
+        else:
+            output = self.exec(cmd)
+
         debug(f"Detecting test interface DPDK id on {self.fqdn}")
 
         for num, line in enumerate(output.splitlines()):

--- a/server.py
+++ b/server.py
@@ -649,8 +649,8 @@ class Server(ABC):
                 self.detect_test_iface_id()
             return
 
-        # bind available interfaces to DPDK
-        self.bind_nics_to_dpdk()
+        # bind test interface to DPDK
+        self.bind_device(self.test_iface_addr, 'igb_uio')
 
         # get the test interface id
         self.detect_test_iface_id()

--- a/server.py
+++ b/server.py
@@ -589,7 +589,12 @@ class Server(ABC):
         Returns
         -------
         """
-        _ = self.exec(f'sudo dpdk-devbind.py -b {driver} {dev_addr}')
+        cmd = f'sudo dpdk-devbind.py -b {driver} {dev_addr}'
+
+        if self.nixos:
+            _ = self.exec(f'nix-shell -p dpdk --run "{cmd}"')
+        else:
+            _ = self.exec(cmd)
 
     def unbind_device(self: 'Server', dev_addr: str) -> None:
         """

--- a/server.py
+++ b/server.py
@@ -642,6 +642,10 @@ class Server(ABC):
         Returns
         -------
         """
+        # detect test interface if not known
+        if not (self.test_iface_addr and self.test_iface_driv):
+            self.detect_test_iface()
+
         # check if test interface is already bound
         if self.is_test_iface_bound():
             debug(f"{self.fqdn}'s test interface already bound to DPDK.")


### PR DESCRIPTION
Revise the Server functions for detecting, binding and unbinding devices or specifically the test interface for use NixOS. The `dpdk-devbind.py` program is available in the NixOS package `dpdk`, so we use `nix-shell -p dpdk --run` if the Server is a NixOS machine.

Resolves #32  